### PR TITLE
Cross thread error reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ deploy:
   password:
     secure: Yrs/AcqfKUkpZ8eY8rTxhZNpVuBlYLRgDpzJt/HJ8SVQmfSR4X7MyO1sCcLXU/Yvbybs/TZs95feah+fQ9TxJqGqIXMLLwN7NX36UGaZNZWjuSunERaq6xbtDq/kuhwix8FK7Bsx2RX61gzrPeLF/+f9H7C3AsH/G6mqlVPQfPxsnzlMaJGJ5CbgfovGUWJBtC+BML+BfARoBo9GWms8v/UQQqFFKrmQw4Js1W9Y/3VS5fBlrEOcKDfNk765ckKHoJDuao3ezpBJ6xQz6G/37F3FoAeKWTQZ1xH0OE9z3z8fjNX9VbeSbjQMfYShf3/wzqdan+O4cbZaZd7GevNLJFYhElNadU0Wq8KhYNdbBdQ3X4pucc5+VSuE+wZgyDcgkgu26X2f9C1qYlUXJKMc1wYgR0sTi00VhmTqs0bpHtEjStI91L/AVJHv/DAbg18PcpmaCOiFeCQxfX9f2egx4WOmNwdJSY4pRQq7YLXBsWrVKBsDXrSD7efbIrWJwxu2N2r3XgB48caNJ0Dvc+oJCQ7v3KwxOxXPUiuxfLRVAoJnWGJ/2TCwxps5DDM0Abp5M93ogSeflgGlHJHCRYCRwt2AKzR9T42K8W9Oq8jglml2i7fghKHHwAfCiM+HodW4cCQ3A+gTFSBV889XsCw7dxePo/K4qwGzM+zu+FQztxE=
   on:
+    # only deploy from protected branches, currently only master is protected
     branch: master
+    # only deploy from one version of python to prevent multiple uploads
+    # of the same version
     python: 3.6
+  # upload wheels for faster installation
   distributions: sdist bdist_wheel

--- a/runtests.sh
+++ b/runtests.sh
@@ -6,7 +6,7 @@ else
     echo "On osx, install from brew, otherwise gem."
 fi
 bashate *.sh
-pylama --skip "*venv/*"
+pylama --skip "*venv/*" --ignore C901
 pytest test_runjenkins.py
 
 if which pandoc; then

--- a/test_runjenkins.py
+++ b/test_runjenkins.py
@@ -12,22 +12,24 @@ class TestRunJenkins(unittest.TestCase):
         # Test Data
         job_name = "testjob"
         params = {"key": "value"}
+        nbn = 10
 
         # Mocks
         server = MagicMock()
-        server.get_job_info = MagicMock(return_value={'nextBuildNumber': 1})
+        server.get_job_info = MagicMock(return_value={'nextBuildNumber': nbn})
         server.build_job = MagicMock()
         server.get_build_info = MagicMock(
             return_value={'building': False,
                           'result': "SUCCESS",
                           'url': "http://buildurl.com"})
+
         # Execute function under test
         runjenkins._runbuild(job_name, params, server)
 
         # Check mock objects for calls
         server.get_job_info.assert_called_with(job_name)
         server.build_job.assert_called_with(job_name, params)
-        server.get_build_info(job_name, 1)
+        server.get_build_info(job_name, nbn)
 
 
 def test_hello_world():


### PR DESCRIPTION
Report failures in threads to the main thread via a queue so that
the return code can be set appropriately.

Also adds an option for checking all jobs referred to by the config
file exist before starting the first build.