### PR TITLE
Install module and properly reference script entry-point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 
 def get_version():
@@ -21,7 +21,7 @@ setup(
     author='Hugh Saunders',
     author_email='hugh@wherenow.org',
     license='Apache',
-    packages=find_packages(),
+    py_modules=['runjenkins'],
     python_requires='>=3',
     version=get_version(),
     install_requires=[
@@ -31,7 +31,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'runjenkins=runjenkins.cli'
+            'runjenkins=runjenkins:cli'
         ]
     }
 )


### PR DESCRIPTION
`runjenkins` is only a module, not a package, so don't use `packages`,
but instead `py_modules` in setup.py.

The `cli` function is to called by the created script, so reference it
using `:`, not `.`.

Fixes #14.